### PR TITLE
typo fix from "trasaction" => "transaction " on index page

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -24,7 +24,7 @@ const Home: NextPage = () => {
           <a className="p-6 mt-6 text-left border border-secondary hover:border-primary w-96 rounded-xl hover:text-primary focus:text-primary-focus">
             <h3 className="text-2xl font-bold">Send to wallet &rarr;</h3>
             <p className="mt-4 text-xl">
-              Execute a trasaction to send funds to a wallet address.
+              Execute a transaction to send funds to a wallet address.
             </p>
           </a>
         </Link>


### PR DESCRIPTION
just a tiny typo fix 